### PR TITLE
update rio-tiler and make threads optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ common: &common
     - run:
         name: run pre-commit
         command: |
-          if [[ "$CIRCLE_JOB" == "python-3.6" ]]; then
+          if [[ "$CIRCLE_JOB" == "python-3.7" ]]; then
              ~/.local/bin/pre-commit run --all-files
           fi
     - run:
@@ -25,13 +25,6 @@ common: &common
         when: always
 
 jobs:
-  "python-2.7":
-    <<: *common
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          - TOXENV=py27
-
   "python-3.6":
     <<: *common
     docker:
@@ -46,6 +39,20 @@ jobs:
       - image: circleci/python:3.7.2
         environment:
           - TOXENV=py37
+
+  benchmark:
+    docker:
+      - image: circleci/python:3.7.2
+    working_directory: ~/rio-tiler-mosaic
+    steps:
+     - checkout
+     - run: pip install -e .[test] --user
+     - run: |
+         python -m pytest \
+         --benchmark-only \
+         --benchmark-autosave \
+         --benchmark-columns 'min, max, mean, median' \
+         --benchmark-sort 'min'
 
   deploy:
       docker:
@@ -79,7 +86,7 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - "python-2.7"
+      - benchmark
       - "python-3.6"
       - "python-3.7":
           filters:  # required since `deploy` has tag filters AND requires `build`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,23 @@
-
 repos:
+    -   
+        repo: https://github.com/pre-commit/mirrors-isort
+        rev: v4.3.21
+        hooks:
+            - id: isort
+              language_version: python3.7
     -
-        repo: 'https://github.com/ambv/black'
-        # 18.6b1
-        rev: ed50737290662f6ef4016a7ea44da78ee1eff1e2
+        repo: 'https://github.com/psf/black'
+        rev: stable
         hooks:
             - id: black
               args: ['--safe']
-              language_version: python3.6
+              language_version: python3.7
     -
         repo: 'https://github.com/pre-commit/pre-commit-hooks'
-        # v1.3.0
-        rev: a6209d8d4f97a09b61855ea3f1fb250f55147b8b
+        rev: v2.4.0 
         hooks:
             - id: flake8
-              language_version: python3.6
+              language_version: python3.7
               args: [
                   # E501 let black handle all line length decisions
                   # W503 black conflicts with "line break before operator" rule
@@ -26,9 +29,16 @@ repos:
         rev: 22d3ccf6cf91ffce3b16caa946c155778f0cb20f
         hooks:
             - id: pydocstyle
-              language_version: python3.6
+              language_version: python3.7
               args: [
                  # Check for docstring presence only
                  '--select=D1',
                  # Don't require docstrings for tests
                  '--match=(?!test).*\.py']
+
+    -   
+        repo: https://github.com/pre-commit/mirrors-mypy
+        rev: 'v0.770'
+        hooks:
+            -   id: mypy
+                args: [--no-strict-optional, --ignore-missing-imports]

--- a/README.md
+++ b/README.md
@@ -54,16 +54,21 @@ Returns:
 #### Examples
 
 ```python
-from rio_tiler.main import tile as cogTiler
+from rio_tiler.io import COGReader
 from rio_tiler_mosaic.mosaic import mosaic_tiler
 from rio_tiler_mosaic.methods import defaults
+
+
+def tiler(src_path: str, *args, **kwargs) -> Tuple[numpy.ndarray, numpy.ndarray]:
+    with COGReader(src_path) as cog:
+        return cog.tile(*args, **kwargs)
 
 assets = ["mytif1.tif", "mytif2.tif", "mytif3.tif"]
 tile = (1000, 1000, 9)
 x, y, z = tile
 
 # Use Default First value method
-mosaic_tiler(assets, x, y, z, cogTiler)
+mosaic_tiler(assets, x, y, z, tiler)
 
 # Use Highest value: defaults.HighestMethod()
 mosaic_tiler(
@@ -71,7 +76,7 @@ mosaic_tiler(
     x,
     y,
     z,
-    cogTiler,
+    tiler,
     pixel_selection=defaults.HighestMethod()
 )
 
@@ -81,7 +86,7 @@ mosaic_tiler(
     x,
     y,
     z,
-    cogTiler,
+    tiler,
     pixel_selection=defaults.LowestMethod()
 )
 ```
@@ -119,8 +124,12 @@ for chunks in _chunks(assets, chunk_size):
     with futures.ThreadPoolExecutor(max_workers=max_threads) as executor:
         future_tasks = [executor.submit(_tiler, asset) for asset in chunks]
 ```
+By default the chunck_size is equal to the number or threads (or the number of assets if no threads=0)
 
-By default the chunck_size is equal to max_threads ([default](https://github.com/cogeotiff/rio-tiler-mosaic/blob/4a4d188a9b0fefbf244af3cf52cf2695db7e0cf1/rio_tiler_mosaic/mosaic.py#L77))
+#### More on threading
+
+The number of threads used can be set in the function call with the `threads=` options. By default it will be equal to `multiprocessing.cpu_count() * 5` or to the MAX_THREADS environment variable.
+In some case, threading can slow down your application. You can set threads to `0` to run the `tiler` outsize a loop.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ By default the chunck_size is equal to the number or threads (or the number of a
 #### More on threading
 
 The number of threads used can be set in the function call with the `threads=` options. By default it will be equal to `multiprocessing.cpu_count() * 5` or to the MAX_THREADS environment variable.
-In some case, threading can slow down your application. You can set threads to `0` to run the `tiler` outsize a loop.
+In some case, threading can slow down your application. You can set threads to `0` to run the tiler in a loop without using a ThreadPool.
 
 ## Example
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-rio-tiler~=1
+rio-tiler~=2.0a

--- a/rio_tiler_mosaic/methods/base.py
+++ b/rio_tiler_mosaic/methods/base.py
@@ -1,14 +1,11 @@
 """rio-tiler-mosaic.methods abc class."""
 
 import abc
+
 import numpy
 
-# Python 2 and 3 compat
-# see https://stackoverflow.com/a/38668373
-ABC = abc.ABCMeta("ABC", (object,), {"__slots__": ()})
 
-
-class MosaicMethodBase(ABC):
+class MosaicMethodBase(abc.ABC):
     """Abstract base class for rio-tiler-mosaic methods objects."""
 
     def __init__(self):

--- a/rio_tiler_mosaic/mosaic.py
+++ b/rio_tiler_mosaic/mosaic.py
@@ -70,7 +70,7 @@ def mosaic_tiler(
         and MUST return a tuple with tile data and mask
         e.g:
         def tiler(asset: str, x: int, y: int, z: int, **kwargs) -> Tuple[numpy.ndarray, numpy.ndarray]:
-            with COGReader(assert) as cog:
+            with COGReader(asset) as cog:
                 return cog.tile(x, y, z, **kwargs)
     pixel_selection: MosaicMethod, optional
         Instance of MosaicMethodBase class.

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,22 @@
 """Setup for rio-tiler-mosaic."""
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 # Runtime requirements.
-inst_reqs = ["rio-tiler>=1.2"]
+inst_reqs = ["rio-tiler~=2.0a"]
 
 extra_reqs = {
-    "test": ["pytest", "pytest-cov"],
-    "dev": ["pytest", "pytest-cov", "pre-commit"],
+    "test": ["pytest", "pytest-cov", "pytest-benchmark"],
+    "dev": ["pytest", "pytest-cov", "pytest-benchmark", "pre-commit"],
 }
-
 
 with open("README.md") as f:
     long_description = f.read()
 
 setup(
     name="rio-tiler-mosaic",
-    version="0.0.1dev4",
+    version="0.0.1dev5",
+    python_requires=">=3",
     long_description=long_description,
     long_description_content_type="text/markdown",
     description=u"""A rio-tiler plugin to create mosaic tiles.""",
@@ -24,7 +24,6 @@ setup(
         "Intended Audience :: Information Technology",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: BSD License",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Topic :: Scientific/Engineering :: GIS",
     ],

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,39 @@
+"""Benchmark."""
+
+import os
+
+import pytest
+import rasterio
+
+from rio_tiler.io import COGReader
+from rio_tiler_mosaic import mosaic
+
+asset1 = os.path.join(os.path.dirname(__file__), "fixtures", "cog1.tif")
+asset2 = os.path.join(os.path.dirname(__file__), "fixtures", "cog2.tif")
+assets = [asset1, asset2, asset1, asset2, asset1, asset2]
+
+
+def _tiler(asset, x, y, z):
+    with COGReader(asset) as cog:
+        return cog.tile(x, y, z)
+
+
+def read_tile(threads, asset_list):
+    """Benchmark rio-tiler.utils._tile_read."""
+    with rasterio.Env(
+        GDAL_CACHEMAX=0, GDAL_DISABLE_READDIR_ON_OPEN="EMPTY_DIR",
+    ):
+        return mosaic.mosaic_tiler(asset_list, 150, 180, 9, _tiler, threads=threads)
+
+
+@pytest.mark.parametrize("threads", [0, 1, 2, 3, 4, 5])
+@pytest.mark.parametrize("nb_image", [1, 2, 3, 4, 5])
+def test_threads(benchmark, nb_image, threads):
+    """Test tile read for multiple combination of datatype/mask/tile extent."""
+    benchmark.name = f"{nb_image}images-{threads}threads"
+    benchmark.group = f"{nb_image}images"
+
+    asset_list = assets[:nb_image]
+
+    tile, _ = benchmark(read_tile, threads, asset_list)
+    assert tile.shape == (3, 256, 256)

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -1,12 +1,13 @@
 """tests ard_tiler.mosaic."""
 
 import os
-import pytest
+from typing import Tuple
 
 import numpy
+import pytest
 
+from rio_tiler.io import COGReader
 from rio_tiler_mosaic import mosaic
-from rio_tiler.main import tile as cogTiler
 from rio_tiler_mosaic.methods import defaults
 
 asset1 = os.path.join(os.path.dirname(__file__), "fixtures", "cog1.tif")
@@ -24,76 +25,93 @@ xp = 150
 yp = 180
 zp = 9
 
+# Outsize tile
+xout = 140
+yout = 130
+zout = 9
+
+
+def _read_tile(src_path: str, *args, **kwargs) -> Tuple[numpy.ndarray, numpy.ndarray]:
+    """Read tile from an asset"""
+    with COGReader(src_path) as cog:
+        tile, mask = cog.tile(*args, **kwargs)
+    return tile, mask
+
 
 def test_mosaic_tiler():
     """Test mosaic tiler."""
+    # should return (None, None) with tile outside bounds
+    t, m = mosaic.mosaic_tiler(assets, xout, yout, zout, _read_tile)
+    assert not t
+    assert not m
+
     # test with default and full covered tile and default options
-    t, m = mosaic.mosaic_tiler(assets, x, y, z, cogTiler)
+    t, m = mosaic.mosaic_tiler(assets, x, y, z, _read_tile)
     assert t.shape == (3, 256, 256)
     assert m.shape == (256, 256)
     assert m.all()
-    assert t[0][-1][-1] == 8000
+    assert t[0][-1][-1] == 8682
 
     # Test last pixel selection
     assetsr = list(reversed(assets))
-    t, m = mosaic.mosaic_tiler(assetsr, x, y, z, cogTiler)
+    t, m = mosaic.mosaic_tiler(assetsr, x, y, z, _read_tile)
     assert t.shape == (3, 256, 256)
     assert m.shape == (256, 256)
     assert m.all()
-    assert t[0][-1][-1] == 7645
+    assert t[0][-1][-1] == 8057
 
-    t, m = mosaic.mosaic_tiler(assets, x, y, z, cogTiler, indexes=1)
+    t, m = mosaic.mosaic_tiler(assets, x, y, z, _read_tile, indexes=1)
     assert t.shape == (1, 256, 256)
     assert m.shape == (256, 256)
     assert t.all()
     assert m.all()
-    assert t[0][-1][-1] == 8000
+    assert t[0][-1][-1] == 8682
 
     # Test darkest pixel selection
     t, m = mosaic.mosaic_tiler(
-        assets, x, y, z, cogTiler, pixel_selection=defaults.LowestMethod()
+        assets, x, y, z, _read_tile, pixel_selection=defaults.LowestMethod()
     )
     assert m.all()
-    assert t[0][-1][-1] == 7645
+    assert t[0][-1][-1] == 8057
 
     to, mo = mosaic.mosaic_tiler(
-        assets_order, x, y, z, cogTiler, pixel_selection=defaults.LowestMethod()
+        assets_order, x, y, z, _read_tile, pixel_selection=defaults.LowestMethod()
     )
     numpy.testing.assert_array_equal(t[0, m], to[0, mo])
 
     # Test brightest pixel selection
     t, m = mosaic.mosaic_tiler(
-        assets, x, y, z, cogTiler, pixel_selection=defaults.HighestMethod()
+        assets, x, y, z, _read_tile, pixel_selection=defaults.HighestMethod()
     )
     assert m.all()
-    assert t[0][-1][-1] == 8000
+    assert t[0][-1][-1] == 8682
 
     to, mo = mosaic.mosaic_tiler(
-        assets_order, x, y, z, cogTiler, pixel_selection=defaults.HighestMethod()
+        assets_order, x, y, z, _read_tile, pixel_selection=defaults.HighestMethod()
     )
     numpy.testing.assert_array_equal(to, t)
     numpy.testing.assert_array_equal(mo, m)
 
     # test with default and partially covered tile
     t, m = mosaic.mosaic_tiler(
-        assets, xp, yp, zp, cogTiler, pixel_selection=defaults.HighestMethod()
+        assets, xp, yp, zp, _read_tile, pixel_selection=defaults.HighestMethod()
     )
     assert t.any()
     assert not m.all()
 
     # test when tiler raise errors (outside bounds)
-    t, m = mosaic.mosaic_tiler(assets, 150, 300, 9, cogTiler)
+    t, m = mosaic.mosaic_tiler(assets, 150, 300, 9, _read_tile)
     assert not t
     assert not m
 
     # Test mean pixel selection
     t, m = mosaic.mosaic_tiler(
-        assets, x, y, z, cogTiler, pixel_selection=defaults.MeanMethod()
+        assets, x, y, z, _read_tile, pixel_selection=defaults.MeanMethod()
     )
     assert t.shape == (3, 256, 256)
     assert m.shape == (256, 256)
     assert m.all()
-    assert t[0][-1][-1] == 7822
+    assert t[0][-1][-1] == 8369
 
     # Test mean pixel selection
     t, m = mosaic.mosaic_tiler(
@@ -101,20 +119,20 @@ def test_mosaic_tiler():
         x,
         y,
         z,
-        cogTiler,
+        _read_tile,
         pixel_selection=defaults.MeanMethod(enforce_data_type=False),
     )
     assert m.all()
-    assert t[0][-1][-1] == 7822.5
+    assert t[0][-1][-1] == 8369.5
 
     # Test median pixel selection
     t, m = mosaic.mosaic_tiler(
-        assets, x, y, z, cogTiler, pixel_selection=defaults.MedianMethod()
+        assets, x, y, z, _read_tile, pixel_selection=defaults.MedianMethod()
     )
     assert t.shape == (3, 256, 256)
     assert m.shape == (256, 256)
     assert m.all()
-    assert t[0][-1][-1] == 7822
+    assert t[0][-1][-1] == 8369
 
     # Test median pixel selection
     t, m = mosaic.mosaic_tiler(
@@ -122,11 +140,11 @@ def test_mosaic_tiler():
         x,
         y,
         z,
-        cogTiler,
+        _read_tile,
         pixel_selection=defaults.MedianMethod(enforce_data_type=False),
     )
     assert m.all()
-    assert t[0][-1][-1] == 7822.5
+    assert t[0][-1][-1] == 8369.5
 
     # Test invalid Pixel Selection class
     with pytest.raises(Exception):
@@ -134,16 +152,16 @@ def test_mosaic_tiler():
         class aClass(object):
             pass
 
-        mosaic.mosaic_tiler(assets, x, y, z, cogTiler, pixel_selection=aClass())
+        mosaic.mosaic_tiler(assets, x, y, z, _read_tile, pixel_selection=aClass())
 
 
 def test_mosaic_tiler_Stdev():
     """Test Stdev mosaic methods."""
-    tile1, mask1 = cogTiler(assets[0], x, y, z)
-    tile2, mask2 = cogTiler(assets[1], x, y, z)
+    tile1, _ = _read_tile(assets[0], x, y, z)
+    tile2, _ = _read_tile(assets[1], x, y, z)
 
     t, m = mosaic.mosaic_tiler(
-        assets, x, y, z, cogTiler, pixel_selection=defaults.StdevMethod()
+        assets, x, y, z, _read_tile, pixel_selection=defaults.StdevMethod()
     )
     assert t.shape == (3, 256, 256)
     assert m.shape == (256, 256)
@@ -151,3 +169,17 @@ def test_mosaic_tiler_Stdev():
     assert t[0][-1][-1] == numpy.std([tile1[0][-1][-1], tile2[0][-1][-1]])
     assert t[1][-1][-1] == numpy.std([tile1[1][-1][-1], tile2[1][-1][-1]])
     assert t[2][-1][-1] == numpy.std([tile1[2][-1][-1], tile2[2][-1][-1]])
+
+
+def test_threads():
+    """Test mosaic tiler."""
+    assets = [asset1, asset2, asset1, asset2, asset1, asset2]
+
+    tnothread, _ = mosaic.mosaic_tiler(assets, x, y, z, _read_tile, threads=0)
+    tmulti_threads, _ = mosaic.mosaic_tiler(assets, x, y, z, _read_tile, threads=1)
+    numpy.testing.assert_array_equal(tnothread, tmulti_threads)
+
+    t, _ = mosaic.mosaic_tiler(assets, x, y, z, _read_tile, threads=0, chunk_size=2)
+    assert t.shape == (3, 256, 256)
+    t, _ = mosaic.mosaic_tiler(assets, x, y, z, _read_tile, threads=2, chunk_size=4)
+    assert t.shape == (3, 256, 256)

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,30 @@
 [tox]
-envlist = py27,py36,py37
+envlist = py36,py37
 
 [testenv]
 extras = test
 commands=
-    python -m pytest --cov rio_tiler_mosaic --cov-report term-missing --ignore=venv
+    python -m pytest --cov rio_tiler_mosaic --cov-report term-missing --ignore=venv --benchmark-skip
 deps=
     numpy
 
-[testenv:black]
-basepython = python3
-skip_install = true
-deps =
-    black
-commands =
-    black
-
+# Lint
 [flake8]
-ignore = D203
 exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
-max-complexity = 10
 max-line-length = 90
+
+[mypy]
+no_strict_optional = True
+ignore_missing_imports = True
+
+[tool:isort]
+include_trailing_comma = True
+multi_line_output = 3
+line_length = 90
+known_first_party = rio_tiler,rio_tiler_mosaic
+known_third_party = rasterio,mercantile,supermercado,affine
+default_section = THIRDPARTY
+
 
 # Release tooling
 [testenv:build]


### PR DESCRIPTION
Takes changes proposed in #13 and update for rio-tiler 2.0

@kylebarron thanks for your PR in #13. I've taken some of your input for this PR and I'll add you in the author list 😄 

This PR does: 
- add `threads` option directly in `mosaic_tiler` function
- enable `no threads` run when threads is set to 0
- switch to python 3 + types
- add benchmark 
- update tests